### PR TITLE
Fix for superfluous sensor reading

### DIFF
--- a/multical402-4-domoticz.py
+++ b/multical402-4-domoticz.py
@@ -313,12 +313,8 @@ print ("Meter vendor/type: Kamstrup M402")
 print ("---------------------------------------------------------------------------------------")
 
 for i in kamstrup_402_var:
-    x,u = foo.readvar(i)
     r = 0
-    
-    print("%-25s" % kamstrup_402_var[i], x, u)
         
-
     for y in index:
         paramater = y.split(':')
         idx = int(paramater[0],0)
@@ -333,6 +329,10 @@ for i in kamstrup_402_var:
         
         # If decimal number matches the command given as argv[2]
         if i == dcNr:
+            x,u = foo.readvar(i)
+          
+            print("%-25s" % kamstrup_402_var[i], x, u)
+           
             value = round(x,2)
 
             # Retrieve devicename and devicedata


### PR DESCRIPTION
As mentioned by Tim (https://github.com/ronaldvdmeer/multical402-4-domoticz/issues/2) the script retrieves all results while only a few are needed. Because I don't have the multical402 I would like to ask @tvwerkhoven if he could test this pull request. 